### PR TITLE
Introducing Oban Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@
   <a href="https://opensource.org/licenses/Apache-2.0">
     <img alt="Apache 2 License" src="https://img.shields.io/hexpm/l/oban">
   </a>
+
+  <a href="https://gurubase.io/g/oban">
+    <img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20Oban%20Guru-006BFF">
+  </a>
 </p>
 
 ## Table of Contents


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Oban Guru](https://gurubase.io/g/oban) to Gurubase. Oban Guru uses the data from this repo and data from the [docs](https://hexdocs.pm/oban/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Oban Guru", which highlights that Oban now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Oban Guru in Gurubase, just let me know that's totally fine.
