### PR TITLE
fix: oban_jobs version query for pgsql dbs with non-unique oid

### DIFF
--- a/lib/oban/migrations/postgres.ex
+++ b/lib/oban/migrations/postgres.ex
@@ -50,9 +50,8 @@ defmodule Oban.Migrations.Postgres do
     escaped_prefix = Map.fetch!(opts, :escaped_prefix)
 
     query = """
-    SELECT description
+    SELECT pg_catalog.obj_description(pg_class.oid, 'pg_class')
     FROM pg_class
-    LEFT JOIN pg_description ON pg_description.objoid = pg_class.oid
     LEFT JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
     WHERE pg_class.relname = 'oban_jobs'
     AND pg_namespace.nspname = '#{escaped_prefix}'


### PR DESCRIPTION
On our production database the `oban_jobs` and the PostGIS function `st_distancesphere` have the same `oid`, so the current Oban table version query returns two rows, and as a consequence starts from the first Oban migration when I run `Oban.Migrations.up(version: 12)`.

```
db=> SELECT description FROM pg_class LEFT JOIN pg_description ON pg_description.objoid = pg_class.oid LEFT JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace WHERE pg_class.relname = 'oban_jobs' AND pg_namespace.nspname = 'public';
                                                                                                                                             description
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 args: geomlonlatA, geomlonlatB - Returns minimum distance in meters between two lon/lat geometries. Uses a spherical earth and radius derived from the spheroid defined by the SRID. Faster than ST_DistanceSpheroid , but less accurate. PostGIS versions prior to 1.5 only implemented for points.
 11
(2 rows)
```

```
db=> \dt+ oban_jobs
                                     List of relations
 Schema |   Name    | Type  |  Owner   | Persistence | Access method | Size  | Description
--------+-----------+-------+----------+-------------+---------------+-------+-------------
 public | oban_jobs | table | xxxxxxxx | permanent   | heap          | 51 MB | 11
(1 row)
```

By using `pg_catalog.obj_description(object_oid, catalog_name)` (introduced in PostgreSQL 7.2) and specifying the `pg_class` catalog, only the `oban_jobs` description is returned.

[Docs for obj_description(object_oid, catalog_name)](https://www.postgresql.org/docs/current/functions-info.html#FUNCTIONS-INFO-COMMENT-TABLE)