### PR TITLE
Add rescue_jobs/3 callback and corresponding Dolphin implementation

### DIFF
--- a/lib/oban/engines/basic.ex
+++ b/lib/oban/engines/basic.ex
@@ -25,6 +25,28 @@ defmodule Oban.Engines.Basic do
     end
   end
 
+  defmacrop rescue_state(attempt, max_attempts, prefix) do
+    quote do
+      fragment(
+        "(CASE WHEN ? < ? THEN 'available' ELSE 'discarded' END)::?.oban_job_state",
+        unquote(attempt),
+        unquote(max_attempts),
+        literal(unquote(prefix))
+      )
+    end
+  end
+
+  defmacrop discarded_at(attempt, max_attempts, at) do
+    quote do
+      fragment(
+        "CASE WHEN ? < ? THEN NULL ELSE ?::timestamp END",
+        unquote(attempt),
+        unquote(max_attempts),
+        unquote(at)
+      )
+    end
+  end
+
   @impl Engine
   def init(%Config{} = conf, opts) do
     if Keyword.has_key?(opts, :limit) do
@@ -175,6 +197,29 @@ defmodule Oban.Engines.Basic do
     {_count, pruned} = Repo.delete_all(conf, query)
 
     {:ok, pruned}
+  end
+
+  @impl Engine
+  def rescue_jobs(%Config{} = conf, queryable, opts) do
+    rescue_after = Keyword.fetch!(opts, :rescue_after)
+
+    now = DateTime.utc_now()
+    cut = DateTime.add(now, -rescue_after, :millisecond)
+
+    query =
+      queryable
+      |> where([j], j.state == "executing" and j.attempted_at < ^cut)
+      |> select([j], map(j, [:id, :queue, :state]))
+      |> update([j],
+        set: [
+          state: rescue_state(j.attempt, j.max_attempts, ^conf.prefix),
+          discarded_at: discarded_at(j.attempt, j.max_attempts, ^now)
+        ]
+      )
+
+    {_, rescued} = Repo.update_all(conf, query, [])
+
+    {:ok, rescued}
   end
 
   @impl Engine

--- a/lib/oban/engines/dolphin.ex
+++ b/lib/oban/engines/dolphin.ex
@@ -175,11 +175,40 @@ defmodule Oban.Engines.Dolphin do
 
     pruned = Repo.all(conf, select_query)
 
-    if Enum.any?(pruned) do
-      Repo.delete_all(conf, where(Job, [j], j.id in ^Enum.map(pruned, & &1.id)))
-    end
+    Repo.delete_all(conf, where(queryable, [j], j.id in ^Enum.map(pruned, & &1.id)))
 
     {:ok, pruned}
+  end
+
+  @impl Engine
+  def rescue_jobs(%Config{} = conf, queryable, opts) do
+    rescue_after = Keyword.fetch!(opts, :rescue_after)
+
+    now = DateTime.utc_now()
+    cut = DateTime.add(now, -rescue_after, :millisecond)
+
+    select_query =
+      queryable
+      |> where([j], j.state == "executing" and j.attempted_at < ^cut)
+      |> select([j], map(j, [:attempt, :id, :max_attempts, :queue]))
+
+    {rescues, discard} =
+      conf
+      |> Repo.all(select_query)
+      |> Enum.reduce({[], []}, fn job, {res_acc, dis_acc} ->
+        if job.attempt < job.max_attempts do
+          {[Map.put(job, :state, "available") | res_acc], dis_acc}
+        else
+          {res_acc, [Map.put(job, :state, "discarded") | dis_acc]}
+        end
+      end)
+
+    to_where = fn jobs -> where(queryable, [j], j.id in ^Enum.map(jobs, & &1.id)) end
+
+    Repo.update_all(conf, to_where.(rescues), set: [state: "available"])
+    Repo.update_all(conf, to_where.(discard), set: [state: "discarded", discarded_at: now])
+
+    {:ok, rescues ++ discard}
   end
 
   @impl Engine

--- a/test/oban/peer_test.exs
+++ b/test/oban/peer_test.exs
@@ -18,7 +18,7 @@ defmodule Oban.PeerTest do
   end
 
   describe "compatibility" do
-    @tag dolphin: true
+    @tag :dolphin
     test "maintaining leadership using the Dolphin engine" do
       name =
         start_supervised_oban!(

--- a/test/oban/plugins/lifeline_test.exs
+++ b/test/oban/plugins/lifeline_test.exs
@@ -36,8 +36,8 @@ defmodule Oban.Plugins.LifelineTest do
       assert_receive {:event, :start, _measure, %{plugin: Lifeline}}
       assert_receive {:event, :stop, _measure, %{plugin: Lifeline} = meta}
 
-      assert %{rescued_count: 1, rescued_jobs: [_ | _]} = meta
-      assert %{discarded_count: 1, discarded_jobs: [_ | _]} = meta
+      assert %{rescued_jobs: [_]} = meta
+      assert %{discarded_jobs: [_]} = meta
 
       assert %{state: "executing"} = Repo.reload(job_1)
       assert %{state: "available"} = Repo.reload(job_2)
@@ -54,7 +54,7 @@ defmodule Oban.Plugins.LifelineTest do
 
       send_rescue(name)
 
-      assert_receive {:event, :stop, _meta, %{plugin: Lifeline, rescued_count: 1}}
+      assert_receive {:event, :stop, _meta, %{plugin: Lifeline, rescued_jobs: [_]}}
 
       assert %{state: "executing"} = Repo.reload(job_1)
       assert %{state: "available"} = Repo.reload(job_2)


### PR DESCRIPTION
This fixes the issues in #1198 by adding a new `rescue_jobs/3` callback and implementing a MySQL specific version. That version requires three queries, but should get the job done.