### PR TITLE
Proposal: Add Oban.json_library/0

### DIFF
--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -1441,6 +1441,19 @@ defmodule Oban do
     {:ok, length(deleted_jobs)}
   end
 
+  @doc """
+  Returns the configured JSON encoding library for Oban.
+
+  To customize the JSON library, including the following
+  in your `config/config.exs`:
+
+      config :oban, :json_library, AlternativeJsonLibrary
+
+  """
+  def json_library do
+    Application.get_env(:oban, :json_library, Jason)
+  end
+
   ## Child Spec Helpers
 
   defp plugin_child_spec({module, opts}, conf) do

--- a/lib/oban/engines/inline.ex
+++ b/lib/oban/engines/inline.ex
@@ -104,8 +104,8 @@ defmodule Oban.Engines.Inline do
 
   defp json_encode_decode(map) do
     map
-    |> Jason.encode!()
-    |> Jason.decode!()
+    |> Oban.json_library().encode!()
+    |> Oban.json_library().decode!()
   end
 
   defp complete_job(%{job: job, state: :failure}) do

--- a/lib/oban/engines/lite.ex
+++ b/lib/oban/engines/lite.ex
@@ -336,7 +336,10 @@ defmodule Oban.Engines.Lite do
               )
 
             true ->
-              dynamic([j], json_contains(field(j, ^field), ^Oban.json_library().encode!(value)) and ^acc)
+              dynamic(
+                [j],
+                json_contains(field(j, ^field), ^Oban.json_library().encode!(value)) and ^acc
+              )
           end
 
         field, acc ->

--- a/lib/oban/engines/lite.ex
+++ b/lib/oban/engines/lite.ex
@@ -327,7 +327,7 @@ defmodule Oban.Engines.Lite do
               dynamic([j], field(j, ^field) == ^value and ^acc)
 
             keys == [] ->
-              encoded = Jason.encode!(value)
+              encoded = Oban.json_library().encode!(value)
 
               dynamic(
                 [j],
@@ -336,7 +336,7 @@ defmodule Oban.Engines.Lite do
               )
 
             true ->
-              dynamic([j], json_contains(field(j, ^field), ^Jason.encode!(value)) and ^acc)
+              dynamic([j], json_contains(field(j, ^field), ^Oban.json_library().encode!(value)) and ^acc)
           end
 
         field, acc ->
@@ -385,6 +385,6 @@ defmodule Oban.Engines.Lite do
   defp encode_unsaved(job) do
     job
     |> Job.format_attempt()
-    |> Jason.encode!()
+    |> Oban.json_library().encode!()
   end
 end

--- a/lib/oban/notifier.ex
+++ b/lib/oban/notifier.ex
@@ -304,7 +304,7 @@ defmodule Oban.Notifier do
   defp encode(payload) do
     payload
     |> to_encodable()
-    |> Jason.encode!()
+    |> Oban.json_library().encode!()
     |> :zlib.gzip()
     |> Base.encode64()
   end
@@ -314,11 +314,11 @@ defmodule Oban.Notifier do
       {:ok, decoded} ->
         decoded
         |> :zlib.gunzip()
-        |> Jason.decode!()
+        |> Oban.json_library().decode!()
 
       # Messages emitted by the insert trigger aren't compressed.
       :error ->
-        Jason.decode!(payload)
+        Oban.json_library().decode!(payload)
     end
   end
 

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -612,7 +612,7 @@ defmodule Oban.Telemetry do
       output = Map.put(fun.(), :source, "oban")
 
       if Keyword.fetch!(opts, :encode) do
-        Jason.encode_to_iodata!(output)
+        Oban.json_library().encode_to_iodata!(output)
       else
         output
       end

--- a/lib/oban/testing.ex
+++ b/lib/oban/testing.ex
@@ -572,8 +572,8 @@ defmodule Oban.Testing do
 
   defp json_recode(map) do
     map
-    |> Jason.encode!()
-    |> Jason.decode!()
+    |> Oban.json_library().encode!()
+    |> Oban.json_library().decode!()
   end
 
   defp assert_valid_result(result) do

--- a/mix.exs
+++ b/mix.exs
@@ -178,7 +178,7 @@ defmodule Oban.MixProject do
     [
       {:ecto_sql, "~> 3.10"},
       {:ecto_sqlite3, "~> 0.9", optional: true},
-      {:jason, "~> 1.1"},
+      {:jason, "~> 1.1", optional: true},
       {:igniter, "~> 0.5", optional: true},
       {:myxql, "~> 0.7", optional: true},
       {:postgrex, "~> 0.16", optional: true},


### PR DESCRIPTION
Elixir 1.18 introduced [official JSON support](https://hexdocs.pm/elixir/changelog.html#json-support). 

This PR adds support to configure the json library used by Oban, in order to allow the use of the official JSON module. 

By default Oban will keep using Jason.

The code is [adapted from Phoenix](https://github.com/phoenixframework/phoenix/blob/v1.7.18/lib/phoenix.ex#L43).