### PR TITLE
Fix for Oban "Configuring Queues" documentation broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ and configuring Oban in your application.
 
 ## Quick Getting Started
 
-  1. [Configure queues](https://hexdocs.pm/oban/configuration.html) and an Ecto repo for Oban to
+  1. [Configure queues](https://hexdocs.pm/oban/Oban.html#module-configuring-queues) and an Ecto repo for Oban to
      use:
 
      ```elixir


### PR DESCRIPTION
README.md has a broken link and this PR fixes the broken link