### PR TITLE
Remove half-sentence from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ support the JSON module once the minimum supported Elixir version is v1.18.
 - [Oban] Start all queues in parallel on initialization.
 
   The midwife now starts queues using an async stream to parallelize startup and minimize boot
-  time for applications with many queues. Previously,
+  time for applications with many queues.
 
 - [Oban] Safely return `nil` from `check_queue/2` when checking queues that aren't running.
 


### PR DESCRIPTION
Seems like a half-sentence was left there trying to describe what happened previously. We should either fully formulate it or delete it - since I don't know what it was previously I opted to remove it but yeah depends on you what is better :)

Also, thanks for oban! :green_heart: 

![IMG_20220601_080610](https://github.com/user-attachments/assets/077edbd7-5bcb-4fe2-99de-51da7ca410bb)
