### PR TITLE
Make oban installer idempotent

### DIFF
--- a/lib/mix/tasks/oban.install.ex
+++ b/lib/mix/tasks/oban.install.ex
@@ -90,12 +90,11 @@ if Code.ensure_loaded?(Igniter) do
           """
 
           igniter
-          |> Igniter.Project.Deps.add_dep({:oban, "~> 2.18"})
           |> Igniter.Project.Config.configure("config.exs", app_name, [Oban], {:code, conf_code})
           |> Igniter.Project.Config.configure("test.exs", app_name, [Oban], {:code, test_code})
           |> Igniter.Project.Application.add_new_child({Oban, {:code, tree_code}}, after: [repo])
           |> Igniter.Project.Formatter.import_dep(:oban)
-          |> Igniter.Libs.Ecto.gen_migration(repo, "add_oban", body: migration)
+          |> Igniter.Libs.Ecto.gen_migration(repo, "add_oban", body: migration, on_exists: :skip)
 
         {:error, igniter} ->
           igniter


### PR DESCRIPTION
by using `on_exists: :skip` when generating the migration, it is safe for other igniter installers (like the one I'm working on) to add `{:oban, "~> 2.0"}` to their `installs` list in their igniters. If oban is present, the installer does nothing, but if not the user gets a full oban installation.

Also removes an unnecessary `add_dep` call which prompts users to change the dep in cases where they have something like `~> 2.0` instead of exactly `~> 2.18`.