### PR TITLE
Fix :get_dynamic_repo with releases

### DIFF
--- a/guides/advanced/scaling.md
+++ b/guides/advanced/scaling.md
@@ -148,6 +148,24 @@ defmodule MyApp.ObanRepo do
 end
 ```
 
+Then add a function to your main Repo
+
+```diff
+defmodule MyApp.Repo do
+  use Ecto.Repo,
+     adapter: Ecto.Adapters.Postgres,
+     otp_app: :my_app
+  
++ def use_dynamic_repo? do
++   if in_transaction?() do
++     MyApp.Repo
++   else
++     MyApp.ObanRepo
++   end
++ end
+end
+```
+
 Then switch the configured `repo`, and use `get_dynamic_repo` to ensure the same repo is used
 within a transaction:
 
@@ -155,7 +173,7 @@ within a transaction:
  config :my_app, Oban,
 -  repo: MyApp.Repo,
 +  repo: MyApp.ObanRepo,
-+  get_dynamic_repo: fn -> if MyApp.Repo.in_transaction?(), do: MyApp.Repo, else: MyApp.ObanRepo end
++  get_dynamic_repo: {MyApp.Repo, :use_dynamic_repo?, []}
    ...
 ```
 

--- a/guides/advanced/scaling.md
+++ b/guides/advanced/scaling.md
@@ -156,7 +156,7 @@ defmodule MyApp.Repo do
      adapter: Ecto.Adapters.Postgres,
      otp_app: :my_app
   
-+ def use_dynamic_repo? do
++ def oban_repo do
 +   if in_transaction?() do
 +     MyApp.Repo
 +   else
@@ -173,7 +173,7 @@ within a transaction:
  config :my_app, Oban,
 -  repo: MyApp.Repo,
 +  repo: MyApp.ObanRepo,
-+  get_dynamic_repo: {MyApp.Repo, :use_dynamic_repo?, []}
++  get_dynamic_repo: {MyApp.Repo, :oban_repo, []}
    ...
 ```
 

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -50,7 +50,7 @@ defmodule Oban do
   @type option ::
           {:dispatch_cooldown, pos_integer()}
           | {:engine, module()}
-          | {:get_dynamic_repo, nil | (-> pid() | atom())}
+          | {:get_dynamic_repo, nil | (-> pid() | atom()) | {module(), atom(), list()}}
           | {:log, false | Logger.level()}
           | {:name, name()}
           | {:node, oban_node()}

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -13,7 +13,7 @@ defmodule Oban.Config do
   @type t :: %__MODULE__{
           dispatch_cooldown: pos_integer(),
           engine: module(),
-          get_dynamic_repo: nil | (-> pid() | atom()),
+          get_dynamic_repo: nil | (-> pid() | atom()) | {module(), atom(), list()},
           insert_trigger: boolean(),
           log: false | Logger.level(),
           name: Oban.name(),
@@ -140,7 +140,8 @@ defmodule Oban.Config do
     Validation.validate_schema(opts,
       dispatch_cooldown: :pos_integer,
       engine: {:behaviour, Oban.Engine},
-      get_dynamic_repo: {:or, [:falsy, {:function, 0}]},
+      get_dynamic_repo:
+        {:or, [:falsy, {:function, 0}, {:custom, &validate_mfa(:get_dynamic_repo, &1)}]},
       insert_trigger: :boolean,
       log: {:enum, @log_levels},
       name: :any,
@@ -384,4 +385,14 @@ defmodule Oban.Config do
   end
 
   defp normalize_plugins(plugins), do: plugins || []
+
+  defp validate_mfa(key, {module, function, args})
+       when is_atom(module) and is_atom(function) and is_list(args) do
+    if function_exported?(module, function, length(args)) do
+      :ok
+    else
+      {:error,
+       "expected #{inspect(Exception.format_mfa(module, function, length(args)))} to exist for #{key} but it does not exist"}
+    end
+  end
 end

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -140,8 +140,7 @@ defmodule Oban.Config do
     Validation.validate_schema(opts,
       dispatch_cooldown: :pos_integer,
       engine: {:behaviour, Oban.Engine},
-      get_dynamic_repo:
-        {:or, [:falsy, {:function, 0}, {:custom, &validate_mfa(:get_dynamic_repo, &1)}]},
+      get_dynamic_repo: {:or, [:falsy, {:function, 0}, :mfa]},
       insert_trigger: :boolean,
       log: {:enum, @log_levels},
       name: :any,
@@ -385,14 +384,4 @@ defmodule Oban.Config do
   end
 
   defp normalize_plugins(plugins), do: plugins || []
-
-  defp validate_mfa(key, {module, function, args})
-       when is_atom(module) and is_atom(function) and is_list(args) do
-    if function_exported?(module, function, length(args)) do
-      :ok
-    else
-      {:error,
-       "expected #{inspect(Exception.format_mfa(module, function, length(args)))} to exist for #{key} but it does not exist"}
-    end
-  end
 end

--- a/lib/oban/validation.ex
+++ b/lib/oban/validation.ex
@@ -167,13 +167,13 @@ defmodule Oban.Validation do
     end
   end
 
-  defp validate_type(:mfa, {module, func, args}, val)
+  defp validate_type(:mfa, key, {module, func, args})
        when is_atom(module) and is_atom(func) and is_list(args) do
     if function_exported?(module, function, length(args)) do
       :ok
     else
       {:error,
-       "expected #{inspect(Exception.format_mfa(module, function, length(args)))} to exist for #{key} but it does not exist"}
+       "missing function #{inspect(Exception.format_mfa(module, function, length(args)))} for #{key}"}
     end
   end
 

--- a/lib/oban/validation.ex
+++ b/lib/oban/validation.ex
@@ -172,8 +172,7 @@ defmodule Oban.Validation do
     if function_exported?(module, func, length(args)) do
       :ok
     else
-      {:error,
-       "missing function #{inspect(Exception.format_mfa(module, func, length(args)))} for #{key}"}
+      {:error, "missing function #{Exception.format_mfa(module, func, length(args))} for #{key}"}
     end
   end
 

--- a/lib/oban/validation.ex
+++ b/lib/oban/validation.ex
@@ -169,7 +169,7 @@ defmodule Oban.Validation do
 
   defp validate_type(:mfa, key, {module, func, args})
        when is_atom(module) and is_atom(func) and is_list(args) do
-    if function_exported?(module, fun, length(args)) do
+    if function_exported?(module, func, length(args)) do
       :ok
     else
       {:error,

--- a/lib/oban/validation.ex
+++ b/lib/oban/validation.ex
@@ -167,6 +167,16 @@ defmodule Oban.Validation do
     end
   end
 
+  defp validate_type(:mfa, {module, func, args}, val)
+       when is_atom(module) and is_atom(func) and is_list(args) do
+    if function_exported?(module, function, length(args)) do
+      :ok
+    else
+      {:error,
+       "expected #{inspect(Exception.format_mfa(module, function, length(args)))} to exist for #{key} but it does not exist"}
+    end
+  end
+
   defp validate_type(:schedule, key, val) do
     case Expression.parse(val) do
       {:ok, _cron} ->

--- a/lib/oban/validation.ex
+++ b/lib/oban/validation.ex
@@ -169,11 +169,11 @@ defmodule Oban.Validation do
 
   defp validate_type(:mfa, key, {module, func, args})
        when is_atom(module) and is_atom(func) and is_list(args) do
-    if function_exported?(module, function, length(args)) do
+    if function_exported?(module, fun, length(args)) do
       :ok
     else
       {:error,
-       "missing function #{inspect(Exception.format_mfa(module, function, length(args)))} for #{key}"}
+       "missing function #{inspect(Exception.format_mfa(module, func, length(args)))} for #{key}"}
     end
   end
 

--- a/test/oban/repo_test.exs
+++ b/test/oban/repo_test.exs
@@ -5,7 +5,23 @@ defmodule Oban.RepoTest do
 
   @moduletag :unboxed
 
-  test "querying with a dynamic repo" do
+  test "querying with a dynamic repo (MFA)" do
+    {:ok, repo_pid} = start_supervised({DynamicRepo, name: nil})
+
+    DynamicRepo.put_dynamic_repo(nil)
+
+    name =
+      start_supervised_oban!(
+        get_dynamic_repo: {DynamicRepo, :use_dynamic_repo, [repo_pid]},
+        repo: DynamicRepo
+      )
+
+    conf = Oban.config(name)
+
+    Oban.Repo.insert!(conf, Worker.new(%{ref: 1, action: "OK"}))
+  end
+
+  test "querying with a dynamic repo (anonymous function)" do
     {:ok, repo_pid} = start_supervised({DynamicRepo, name: nil})
 
     DynamicRepo.put_dynamic_repo(nil)

--- a/test/support/repo.ex
+++ b/test/support/repo.ex
@@ -13,6 +13,10 @@ defmodule Oban.Test.DynamicRepo do
     otp_app: :oban,
     adapter: Ecto.Adapters.Postgres
 
+  def use_dynamic_repo(pid) do
+    pid
+  end
+
   def init(_, _) do
     {:ok, Oban.Test.Repo.config()}
   end


### PR DESCRIPTION
Lave Ducia here, long-time user, ~~first-time~~ second-time contributor!

It seems that the recommendation for a [separate Oban pool](https://hexdocs.pm/oban/scaling.html#pooling) does not work with OTP releases, as anonymous functions cannot be used in configuration.

This PR allows an MFA tuple to be passed instead, and updates the documentation to recommend this instead.