### PR TITLE
Add next_at/2 and last_at/2 for cron time calculations

### DIFF
--- a/lib/oban/cron/expression.ex
+++ b/lib/oban/cron/expression.ex
@@ -37,6 +37,12 @@ defmodule Oban.Cron.Expression do
     "DEC" => "12"
   }
 
+  @min_range 0..59
+  @hrs_range 0..23
+  @day_range 1..31
+  @mon_range 1..12
+  @dow_range 0..6
+
   @spec now?(cron :: t(), datetime :: DateTime.t()) :: boolean()
   def now?(cron, datetime \\ DateTime.utc_now())
 
@@ -57,9 +63,122 @@ defmodule Oban.Cron.Expression do
   defp included?({:reboot?, _}, _datetime), do: true
 
   defp day_of_week(datetime) do
-    datetime
-    |> Date.day_of_week()
-    |> Integer.mod(7)
+    if days_in_month(datetime) <= datetime.day do
+      datetime
+      |> Date.day_of_week()
+      |> Integer.mod(7)
+    else
+      0
+    end
+  end
+
+  @spec last_at(t(), DateTime.t() | Calendar.timezone()) :: DateTime.t()
+  def last_at(expr, timezone \\ "Etc/UTC")
+
+  def last_at(%{reboot?: true}, _timezone_or_datetime) do
+    {ms, _} = :erlang.statistics(:wall_clock)
+
+    DateTime.utc_now()
+    |> DateTime.add(-ms, :millisecond)
+    |> DateTime.truncate(:second)
+    |> Map.put(:second, 0)
+  end
+
+  def last_at(expr, timezone) when is_binary(timezone) do
+    last_at(expr, DateTime.now!(timezone))
+  end
+
+  def last_at(expr, time) when is_struct(time, DateTime) do
+    time =
+      time
+      |> DateTime.add(-1, :minute)
+      |> DateTime.truncate(:second)
+      |> Map.put(:second, 0)
+
+    vals =
+      expr
+      |> Map.from_struct()
+      |> Map.drop([:reboot?])
+      |> Map.new(fn {key, val} -> {key, Enum.sort(val, :desc)} end)
+
+    Process.put(:recur, 0)
+
+    last_match_at(expr, vals, time)
+  end
+
+  defp last_match_at(expr, vals, time) when is_struct(time, DateTime) do
+    case Process.get(:recur) do
+      val when val > 10 -> raise RuntimeError, inspect(time)
+      val -> Process.put(:recur, val + 1)
+    end
+
+    IO.inspect(time)
+
+    cond do
+      now?(expr, time) ->
+        time
+
+      not MapSet.member?(expr.months, time.month) ->
+        last_match_at(expr, vals, prev_month(vals, time))
+
+      not MapSet.member?(expr.days, time.day) ->
+        last_match_at(expr, vals, prev_day(vals, time))
+
+      not MapSet.member?(expr.hours, time.hour) ->
+        last_match_at(expr, vals, prev_hour(vals, time))
+
+      true ->
+        last_match_at(expr, vals, prev_minute(vals, time))
+    end
+  end
+
+  defp prev_month(vals, time) do
+    case Enum.find(vals.months, &(&1 <= time.month)) do
+      nil ->
+        %{time | day: 31, month: 12, year: time.year - 1}
+
+      month ->
+        day = days_in_month(%{time | month: month})
+
+        %{time | day: day, month: month}
+    end
+  end
+
+  defp prev_day(vals, time) do
+    days_in_month = days_in_month(time)
+
+    matches_weekday? = fn day ->
+      day <= days_in_month and
+        time.year
+        |> Date.new!(time.month, day)
+        |> Date.day_of_week()
+        |> then(&(&1 in vals.weekdays))
+    end
+
+    case Enum.find(vals.days, &(matches_weekday?.(&1) and &1 <= time.day)) do
+      nil -> prev_month(vals, time)
+      day -> %{time | day: day, hour: 23}
+    end
+  end
+
+  defp prev_hour(vals, time) do
+    case Enum.find(vals.hours, &(&1 <= time.hour)) do
+      nil -> prev_day(vals, time)
+      hour -> %{time | hour: hour, minute: 59}
+    end
+  end
+
+  defp prev_minute(vals, time) do
+    case Enum.find(vals.minutes, &(&1 < time.minute)) do
+      nil -> prev_hour(vals, time)
+      minute -> %{time | minute: minute}
+    end
+  end
+
+  defp days_in_month(time) do
+    time
+    |> DateTime.to_date()
+    |> Date.days_in_month()
   end
 
   @spec parse(input :: binary()) :: {:ok, t()} | {:error, Exception.t()}
@@ -77,11 +196,11 @@ defmodule Oban.Cron.Expression do
       [mip, hrp, dap, mop, wdp] ->
         {:ok,
          %__MODULE__{
-           minutes: parse_field(mip, 0..59),
-           hours: parse_field(hrp, 0..23),
-           days: parse_field(dap, 1..31),
-           months: mop |> trans_field(@mon_map) |> parse_field(1..12),
-           weekdays: wdp |> trans_field(@dow_map) |> parse_field(0..6)
+           minutes: parse_field(mip, @min_range),
+           hours: parse_field(hrp, @hrs_range),
+           days: parse_field(dap, @day_range),
+           months: mop |> trans_field(@mon_map) |> parse_field(@mon_range),
+           weekdays: wdp |> trans_field(@dow_map) |> parse_field(@dow_range)
          }}
 
       _parts ->

--- a/test/oban/cron/expression_test.exs
+++ b/test/oban/cron/expression_test.exs
@@ -92,11 +92,53 @@ defmodule Oban.Cron.ExpressionTest do
     end
   end
 
+  describe "last_at/2" do
+    defp last_at(expr, time) do
+      expr
+      |> Expr.parse!()
+      |> Expr.last_at(time)
+    end
+
+    test "returning the system start time for @reboot" do
+      time = DateTime.utc_now()
+      last = last_at("@reboot", time)
+
+      assert DateTime.after?(time, last)
+    end
+
+    test "calculating the last time a cron matched" do
+      assert ~U[2024-11-21 00:54:00Z] == last_at("* * * * *", ~U[2024-11-21 00:55:00Z])
+      assert ~U[2024-11-21 00:54:00Z] == last_at("*/2 * * * *", ~U[2024-11-21 00:55:00Z])
+      assert ~U[2024-11-21 00:05:00Z] == last_at("5 * * * *", ~U[2024-11-21 00:06:00Z])
+      assert ~U[2024-11-21 01:00:00Z] == last_at("0 1 * * *", ~U[2024-11-21 01:02:00Z])
+      assert ~U[2024-11-21 02:00:00Z] == last_at("0 */2 * * *", ~U[2024-11-21 03:02:00Z])
+      assert ~U[2024-11-01 00:00:00Z] == last_at("0 0 1 * *", ~U[2024-11-21 01:01:00Z])
+      assert ~U[2024-09-05 02:00:00Z] == last_at("0 0-2 5 9 *", ~U[2024-11-21 01:01:00Z])
+      assert ~U[2023-09-05 02:00:00Z] == last_at("0 0-2 5 9 *", ~U[2024-09-04 00:00:00Z])
+      assert ~U[2022-09-05 01:00:00Z] == last_at("0 1 5 8-9 SUN", ~U[2024-11-21 00:00:00Z])
+    end
+
+    property "the last_at time is always in the past" do
+      check all minutes <- minutes(),
+                hours <- hours(),
+                days <- days(),
+                months <- months() do
+        last =
+          [minutes, hours, days, months, "*"]
+          |> Enum.join(" ")
+          |> Expr.parse!()
+          |> Expr.last_at()
+
+        assert DateTime.before?(last, DateTime.utc_now())
+      end
+    end
+  end
+
   defp minutes, do: expression(0..59)
 
   defp hours, do: expression(0..23)
 
-  defp days, do: expression(1..31)
+  defp days, do: expression(1..28)
 
   defp months do
     one_of([

--- a/test/oban/cron/expression_test.exs
+++ b/test/oban/cron/expression_test.exs
@@ -115,7 +115,7 @@ defmodule Oban.Cron.ExpressionTest do
       assert ~U[2024-11-01 00:00:00Z] == last_at("0 0 1 * *", ~U[2024-11-21 01:01:00Z])
       assert ~U[2024-09-05 02:00:00Z] == last_at("0 0-2 5 9 *", ~U[2024-11-21 01:01:00Z])
       assert ~U[2023-09-05 02:00:00Z] == last_at("0 0-2 5 9 *", ~U[2024-09-04 00:00:00Z])
-      assert ~U[2022-09-05 01:00:00Z] == last_at("0 1 5 8-9 SUN", ~U[2024-11-21 00:00:00Z])
+      assert ~U[2022-09-05 01:00:00Z] == last_at("0 1 5 9 MON", ~U[2024-11-21 00:00:00Z])
     end
 
     property "the last_at time is always in the past" do


### PR DESCRIPTION
This implements jumping functions for cron expressions. Rather than naively iterating through minutes, it uses the expression values to efficiently jump to the next or last cron run time.