### PR TITLE
fix(executor): convert queue_time to native time unit as per docs

### DIFF
--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -198,6 +198,7 @@ defmodule Oban.Queue.Executor do
       exec.job.attempted_at
       |> DateTime.diff(exec.job.scheduled_at, :nanosecond)
       |> max(0)
+      |> System.convert_time_unit(:nanosecond, :native)
 
     %{exec | duration: duration, queue_time: queue_time, stop_mono: stop_mono}
   end


### PR DESCRIPTION
https://hexdocs.pm/oban/Oban.Telemetry.html says all time measurements are recorded in `native` time units.  
However, since https://github.com/oban-bg/oban/commit/566f0f68f77c3d8124acff84e2866e62cdfbf4dd this has not been the case for `queue_time`.

It works anyway, because native and nanosecond is of the same resolution.  
Erlang gives no such guarantee though: https://www.erlang.org/doc/apps/erts/erlang#t:time_unit/0

Although potentially irrelevant, this commit ensures that if the resolution of the time unit changes in the future, the code will still work as expected.