### PR TITLE
Fix the Unique Jobs guide link

### DIFF
--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -155,7 +155,7 @@ defmodule Oban.Worker do
   to **schedule** jobs in the future, see the guide for [*Scheduling Jobs*](scheduling_jobs.html).
 
   See `Oban.Job` for all available options, and the
-  [*Job Uniqueness* guide](job_uniqueness.html) for more information about unique jobs.
+  [*Unique Jobs* guide](unique_jobs.html) for more information about unique jobs.
 
   ## Customizing Backoff
 


### PR DESCRIPTION
The changes fix a broken link to the unique jobs guide from the worker documentation.

I've checked the docs and the codebase for other references to `job_uniqueness.html`. It seems the only place that references the guide.