### PR TITLE
Add callback for new/1 to Worker

### DIFF
--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -363,6 +363,7 @@ defmodule Oban.Worker do
 
   See `Oban.Job.new/2` for the available options.
   """
+  @callback new(args :: Job.args()) :: Job.changeset()
   @callback new(args :: Job.args(), opts :: [Job.option()]) :: Job.changeset()
 
   @doc """


### PR DESCRIPTION
If you try to override new in `Worker`, it is not possible because `new/1` is not included in `defoverridable` due to the absence of a corresponding callback.

To resolve this issue, we add a `new/1` callback to `Worker`.

```elixir
defmodule MyWorker do
  use Oban.Woker, ...

  @impl Oban.Worker
  def new(args, opts \\ [])  when is_map(args) and is_list(opts) do
    ...
  end
end
```

compile warnings

```
warning: this clause for new/1 cannot match because a previous clause at line 3 always matches
    │
  3 │   Defines a behavior and macro to guide the creation of worker modules.
    │   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ deps/oban/lib/oban/worker.ex:3
```