### PR TITLE
Improve warning on incorrect return from perform/1

### DIFF
--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -339,7 +339,7 @@ defmodule Oban.Queue.Executor do
   defp log_warning(%__MODULE__{safe: true, worker: worker}, returned) do
     Logger.warning(fn ->
       """
-      Expected #{worker}.perform/1 to return:
+      Expected #{inspect(worker)}.perform/1 to return:
 
       - `:ok`
       - `:discard`


### PR DESCRIPTION
Before this patch it was:

    20:44:32.851 [warning] Expected Elixir.Worker.perform/1 to return:
    (...)

Now it's gonna be:

    20:44:32.851 [warning] Expected Worker.perform/1 to return:
    (...)
