### PR TITLE
chore: Move preferred_cli_env into def cli

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,12 +13,6 @@ defmodule Oban.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),
-      preferred_cli_env: [
-        bench: :test,
-        "test.ci": :test,
-        "test.reset": :test,
-        "test.setup": :test
-      ],
       xref: [exclude: [Postgrex.Error, MyXQL.Error]],
 
       # Hex
@@ -50,6 +44,10 @@ defmodule Oban.MixProject do
         skip_undefined_reference_warnings_on: ["CHANGELOG.md"]
       ]
     ]
+  end
+
+  def cli do
+    [preferred_envs: [bench: :test, "test.ci": :test, "test.reset": :test, "test.setup": :test]]
   end
 
   def application do


### PR DESCRIPTION
Fixes another Elixir 1.19 deprecation: https://hexdocs.pm/elixir/main/changelog.html

`def cli` was introduced in 1.15 so it's backward compatible down to that version (which also matches the minimum version requirement currently listed in the README -> https://github.com/oban-bg/oban?tab=readme-ov-file#requirements)