### PR TITLE
chore: Fix flaky test cases in cron_test.exs

### DIFF
--- a/test/oban/plugins/cron_test.exs
+++ b/test/oban/plugins/cron_test.exs
@@ -1,5 +1,5 @@
 defmodule Oban.Plugins.CronTest do
-  use Oban.Case, async: true
+  use Oban.Case, async: false
 
   alias Oban.Cron.Expression
   alias Oban.Plugins.Cron


### PR DESCRIPTION
This commit addresses two flaky test cases in cron_text.exs where `inserted_refs!` returns multiple jobs.

```
 1) test evaluating reboot after acquiring leadership (Oban.Plugins.CronTest)
     test/oban/plugins/cron_test.exs:123
     Assertion with == failed
     code:  assert [1] == inserted_refs()
     left:  [1]
     right: [1, 1]
     stacktrace:
       test/oban/plugins/cron_test.exs:140: (test)

  2) test cron jobs are scheduled using the configured timezone (Oban.Plugins.CronTest)
     test/oban/plugins/cron_test.exs:86
     Assertion with == failed
     code:  assert [1] == inserted_refs()
     left:  [1]
     right: [1, 1]
     stacktrace:
       test/oban/plugins/cron_test.exs:98: (test)
```

<details><summary>Details</summary>
<p>
dbg() output from `def inserted_refs/0`

```
[test/oban/plugins/cron_test.exs:181: Oban.Plugins.CronTest.inserted_refs/0]
Job #=> Oban.Job
|> Repo.all() #=> [
  %Oban.Job{
    __meta__: #Ecto.Schema.Metadata<:loaded, "oban_jobs">,
    id: 5526,
    state: "available",
    queue: "alpha",
    worker: "Oban.Integration.Worker",
    args: %{
      "action" => "OK",
      "bin_pid" => "g1h3DW5vbm9kZUBub2hvc3QAAAGyAAAAAAAAAAA=",
      "ref" => 1
    },
    meta: %{},
    tags: [],
    errors: [],
    attempt: 0,
    attempted_by: nil,
    max_attempts: 20,
    priority: 0,
    attempted_at: nil,
    cancelled_at: nil,
    completed_at: nil,
    discarded_at: nil,
    inserted_at: ~U[2025-03-12 09:56:40.774371Z],
    scheduled_at: ~U[2025-03-12 09:56:40.774371Z],
    conf: nil,
    conflict?: false,
    replace: nil,
    unique: nil,
    unsaved_error: nil
  },
  %Oban.Job{
    __meta__: #Ecto.Schema.Metadata<:loaded, "oban_jobs">,
    id: 5527,
    state: "available",
    queue: "alpha",
    worker: "Oban.Integration.Worker",
    args: %{
      "action" => "OK",
      "bin_pid" => "g1h3DW5vbm9kZUBub2hvc3QAAALmAAAAAAAAAAA=",
      "ref" => 1
    },
    meta: %{"cron" => true, "cron_expr" => "@reboot", "cron_tz" => "Etc/UTC"},
    tags: [],
    errors: [],
    attempt: 0,
    attempted_by: nil,
    max_attempts: 20,
    priority: 0,
    attempted_at: nil,
    cancelled_at: nil,
    completed_at: nil,
    discarded_at: nil,
    inserted_at: ~U[2025-03-12 09:56:40.691725Z],
    scheduled_at: ~U[2025-03-12 09:56:40.691725Z],
    conf: nil,
    conflict?: false,
    replace: nil,
    unique: nil,
    unsaved_error: nil
  }
]

.

  1) test evaluating reboot after acquiring leadership (Oban.Plugins.CronTest)
     test/oban/plugins/cron_test.exs:123
     Assertion with == failed
     code:  assert [1] == inserted_refs()
     left:  [1]
     right: [1, 1]
     stacktrace:
       test/oban/plugins/cron_test.exs:140: (test)
```

</p>
</details> 
