### PR TITLE
Correct staleness logic

### DIFF
--- a/lib/oban/sonar.ex
+++ b/lib/oban/sonar.ex
@@ -115,8 +115,9 @@ defmodule Oban.Sonar do
   end
 
   defp prune_stale_nodes(state) do
-    stale = System.monotonic_time(:millisecond) + state.interval * state.stale_mult
-    nodes = Map.reject(state.nodes, fn {_, recorded} -> recorded > stale end)
+    now = System.monotonic_time(:millisecond)
+    threshold = state.interval * state.stale_mult
+    nodes = Map.reject(state.nodes, fn {_, recorded} -> now - recored > threshold end)
 
     %{state | nodes: nodes}
   end

--- a/lib/oban/sonar.ex
+++ b/lib/oban/sonar.ex
@@ -117,7 +117,7 @@ defmodule Oban.Sonar do
   defp prune_stale_nodes(state) do
     now = System.monotonic_time(:millisecond)
     threshold = state.interval * state.stale_mult
-    nodes = Map.reject(state.nodes, fn {_, recorded} -> now - recored > threshold end)
+    nodes = Map.reject(state.nodes, fn {_, recorded} -> now - recorded > threshold end)
 
     %{state | nodes: nodes}
   end


### PR DESCRIPTION
We wanted to use `Oban.Notifier.status/0` in a healthcheck to see if we had a broken notifier connection. When testing this locally we found that the local node never got stale and was never removed from the list of nodes in Sonar.

After some thinking about it we think the logic is incorrect and something like this is correct. Tested it locally by running the node, closing the database and seeing that it was pruned after the threshold time had past.