### PR TITLE
Disallow :keys when :fields don't contain :args or :meta

### DIFF
--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -651,7 +651,7 @@ defmodule Oban.Job do
       not (is_list(keys) and Enum.all?(keys, &is_atom/1)) ->
         {:error, "expected :keys to be a list of atoms"}
 
-      is_nil(keys) and Enum.any?(@keyable_fields, &(&1 in Keyword.get(unique, :fields)))) ->
+      not (is_list(keys) and Enum.any?(@keyable_fields, &(&1 in Keyword.get(unique, :fields)))) ->
         {:error,
          "using :keys expects :fields to contain at least one of #{inspect(@keyable_fields)}"}
 

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -201,7 +201,7 @@ defmodule Oban.Job do
 
   @unique_fields ~w(args meta queue worker)a
   @unique_timestamps ~w(inserted_at scheduled_at)a
-  @key_compatible_fields ~w(args meta)a
+  @keyable_fields ~w(args meta)a
 
   @unique_defaults %{
     fields: ~w(args queue worker)a,
@@ -651,10 +651,9 @@ defmodule Oban.Job do
       not (is_list(keys) and Enum.all?(keys, &is_atom/1)) ->
         {:error, "expected :keys to be a list of atoms"}
 
-      not (is_list(keys) and
-               Enum.any?(@key_compatible_fields, &(&1 in Keyword.get(unique, :fields)))) ->
+      is_nil(keys) and Enum.any?(@keyable_fields, &(&1 in Keyword.get(unique, :fields)))) ->
         {:error,
-         "using :keys expects :fields to contain at least one of #{inspect(@key_compatible_fields)}"}
+         "using :keys expects :fields to contain at least one of #{inspect(@keyable_fields)}"}
 
       true ->
         :ok

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -645,10 +645,14 @@ defmodule Oban.Job do
 
   defp validate_keys(keys, unique) do
     cond do
+      keys == [] ->
+        :ok
+
       not (is_list(keys) and Enum.all?(keys, &is_atom/1)) ->
         {:error, "expected :keys to be a list of atoms"}
 
-      not Enum.any?(@key_compatible_fields, &(&1 in Keyword.get(unique, :fields))) ->
+      not (is_list(keys) and
+               Enum.any?(@key_compatible_fields, &(&1 in Keyword.get(unique, :fields)))) ->
         {:error,
          "using :keys expects :fields to contain at least one of #{inspect(@key_compatible_fields)}"}
 

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -201,6 +201,7 @@ defmodule Oban.Job do
 
   @unique_fields ~w(args meta queue worker)a
   @unique_timestamps ~w(inserted_at scheduled_at)a
+  @key_compatible_fields ~w(args meta)a
 
   @unique_defaults %{
     fields: ~w(args queue worker)a,
@@ -612,9 +613,7 @@ defmodule Oban.Job do
         end
 
       {:keys, keys} ->
-        if not (is_list(keys) and Enum.all?(keys, &is_atom/1)) do
-          {:error, "expected :keys to be a list of atoms"}
-        end
+        validate_keys(keys, unique)
 
       {:period, :infinity} ->
         :ok
@@ -642,5 +641,19 @@ defmodule Oban.Job do
       option ->
         {:error, "unknown option, #{inspect(option)}"}
     end)
+  end
+
+  defp validate_keys(keys, unique) do
+    cond do
+      not (is_list(keys) and Enum.all?(keys, &is_atom/1)) ->
+        {:error, "expected :keys to be a list of atoms"}
+
+      not Enum.any?(@key_compatible_fields, &(&1 in Keyword.get(unique, :fields))) ->
+        {:error,
+         "using :keys expects :fields to contain at least one of #{inspect(@key_compatible_fields)}"}
+
+      true ->
+        :ok
+    end
   end
 end

--- a/test/oban/job_test.exs
+++ b/test/oban/job_test.exs
@@ -130,7 +130,13 @@ defmodule Oban.JobTest do
       assert Job.new(%{}, worker: Fake, unique: [timestamp: :updated_at]).errors[:unique]
     end
 
+    test "empty keys don't require args or meta in fields" do
+      assert Job.new(%{}, worker: Fake, unique: [keys: [], fields: [:worker]]).valid?
+    end
+
     test "unique keys are accepted with args or meta in fields" do
+      assert Job.new(%{}, worker: Fake, unique: [keys: [], fields: [:worker, :args]]).valid?
+
       assert Job.new(%{}, worker: Fake, unique: [keys: [:some_key], fields: [:worker, :args]]).valid?
 
       assert Job.new(%{}, worker: Fake, unique: [keys: [:some_key], fields: [:worker, :meta]]).valid?

--- a/test/oban/job_test.exs
+++ b/test/oban/job_test.exs
@@ -129,6 +129,32 @@ defmodule Oban.JobTest do
       assert Job.new(%{}, worker: Fake, unique: [states: [:random]]).errors[:unique]
       assert Job.new(%{}, worker: Fake, unique: [timestamp: :updated_at]).errors[:unique]
     end
+
+    test "unique keys are accepted with args or meta in fields" do
+      assert Job.new(%{}, worker: Fake, unique: [keys: [:some_key], fields: [:worker, :args]]).valid?
+
+      assert Job.new(%{}, worker: Fake, unique: [keys: [:some_key], fields: [:worker, :meta]]).valid?
+
+      assert Job.new(%{}, worker: Fake, unique: [keys: [:some_key], fields: [:args]]).valid?
+      assert Job.new(%{}, worker: Fake, unique: [keys: [:some_key], fields: [:meta]]).valid?
+    end
+
+    test "unique keys are rejected without args or meta in fields" do
+      assert Job.new(%{},
+               worker: Fake,
+               unique: [keys: [:some_key], fields: []]
+             ).errors[:unique]
+
+      assert Job.new(%{},
+               worker: Fake,
+               unique: [keys: [:some_key], fields: [:worker]]
+             ).errors[:unique]
+
+      assert Job.new(%{},
+               worker: Fake,
+               unique: [keys: [:some_key], fields: [:worker, :queue]]
+             ).errors[:unique]
+    end
   end
 
   describe "replace options with new/2" do


### PR DESCRIPTION
# Context

According to the docs on [Unique Jobs](https://hexdocs.pm/oban/2.19.4/unique_jobs.html):

> `:keys` — A specific subset of the `:args` or `:meta` to consider when comparing against historic jobs. This allows a job with multiple key/value pairs in its arguments to be compared using only a subset of them.

However users are currently allowed to insert jobs with a  `:keys` configuration, even when neither `:args` nor `:meta` are passed, e.g.

```elixir
use Oban.Worker,
  unique: [
    keys: [:my_identifier],
    fields: [:worker]
  ]
  ```
  
  the above setup is allowed without any indication that `:keys` will be ignored.
  
  # Solution
  
  This MR adds validation for the above case when the `Job` changeset is validated.