### PR TITLE
Add index state discarded_at / state cancelled_at

### DIFF
--- a/lib/oban/migrations/postgres/v13.ex
+++ b/lib/oban/migrations/postgres/v13.ex
@@ -1,0 +1,10 @@
+defmodule Oban.Migrations.Postgres.V13 do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    create index(:oban_jobs, [:state, :cancelled_at])
+    create index(:oban_jobs, [:state, :discarded_at])
+  end
+end


### PR DESCRIPTION
Hi! After upgrading to the latest release we noticed that cancelled / discarded jobs are [now being properly pruned](https://github.com/oban-bg/oban/commit/861dfa55e4e3e3cf65a3882baccca64c7fbcbc3d#diff-dae8a75e38cc8e3b8a29cf54657560da701f191a872e9d47c6c4fbf4c036cabcR157-R158) 🙌 , but we noticed that the pruner query got a lot slower. We tracked this to be due to two nonexisting indexes. Let me know if anything can be improved!
