### PR TITLE
FIX: Error message when the crontab has an invalid range

### DIFF
--- a/lib/oban/validation.ex
+++ b/lib/oban/validation.ex
@@ -124,12 +124,8 @@ defmodule Oban.Validation do
   end
 
   defp validate_type({:custom, fun}, key, val) when is_function(fun, 1) do
-    with {:error, message} <- fun.(val) do
-      message =
-        case message do
-          %ArgumentError{message: message} -> message
-          other -> other
-        end
+    with {:error, error} <- fun.(val) do
+      message = if is_exception(error), do: error.message, else: error
 
       {:error, "invalid value for #{inspect(key)}, #{message}"}
     end

--- a/lib/oban/validation.ex
+++ b/lib/oban/validation.ex
@@ -125,6 +125,12 @@ defmodule Oban.Validation do
 
   defp validate_type({:custom, fun}, key, val) when is_function(fun, 1) do
     with {:error, message} <- fun.(val) do
+      message =
+        case message do
+          %ArgumentError{message: message} -> message
+          other -> other
+        end
+
       {:error, "invalid value for #{inspect(key)}, #{message}"}
     end
   end

--- a/test/oban/plugins/cron_test.exs
+++ b/test/oban/plugins/cron_test.exs
@@ -42,6 +42,14 @@ defmodule Oban.Plugins.CronTest do
       )
     end
 
+    test ":crontab worker range expression is validated" do
+      refute_valid(
+        crontab: [
+          {"* * * * SAT-SUN", CronWork, args: worker_args(1)}
+        ]
+      )
+    end
+
     test ":crontab worker options are validated" do
       refute_valid("expected valid job options", crontab: [{"* * * * *", CronWork, priority: -1}])
     end

--- a/test/oban/plugins/cron_test.exs
+++ b/test/oban/plugins/cron_test.exs
@@ -43,11 +43,7 @@ defmodule Oban.Plugins.CronTest do
     end
 
     test ":crontab worker range expression is validated" do
-      refute_valid(
-        crontab: [
-          {"* * * * SAT-SUN", CronWork, args: worker_args(1)}
-        ]
-      )
+      refute_valid(crontab: [{"* * * * SAT-SUN", CronWork}])
     end
 
     test ":crontab worker options are validated" do


### PR DESCRIPTION
This fixes the error message when the crontab expression is invalid. Previously it would fail with:
```
  ** (Protocol.UndefinedError) protocol String.Chars not implemented for %ArgumentError{message: "left side (6) of a range must be less than or equal to the right side (0)"} of type ArgumentError (a struct). This protocol is implemented for the following type(s): Atom, BitString, Date, DateTime, Decimal, Exqlite.Query, Float, Integer, List, MyXQL.Queries, MyXQL.Query, MyXQL.TextQueries, MyXQL.TextQuery, NaiveDateTime, Postgrex.Copy, Postgrex.Query, Time, URI, Version, Version.Requirement
     code: refute_valid(
     stacktrace:
       (elixir 1.16.3) lib/string/chars.ex:3: String.Chars.impl_for!/1
       (elixir 1.16.3) lib/string/chars.ex:22: String.Chars.to_string/1
       (oban 2.19.4) lib/oban/validation.ex:128: Oban.Validation.validate_type/3
       (oban 2.19.4) lib/oban/validation.ex:39: anonymous fn/3 in Oban.Validation.validate_schema/2
       (elixir 1.16.3) lib/enum.ex:4839: Enumerable.List.reduce/3
       (elixir 1.16.3) lib/enum.ex:2582: Enum.reduce_while/3
       test/oban/plugins/cron_test.exs:167: Oban.Plugins.CronTest.refute_valid/1
       test/oban/plugins/cron_test.exs:96: (test)
```