### PR TITLE
Fix Oban Pro link in Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 ## Table of Contents
 
 - [Features](#features)
-- [Oban Pro](#oban-pro)
+- [Oban Pro](#-oban-pro)
 - [Engines](#engines)
 - [Requirements](#requirements)
 - [Installation](#installation)


### PR DESCRIPTION
Looks like the :star2: added by commit 62b87db23221adc713fb3ec8c5732166e5bd1e28 broke the link in Table of Contents to Oban Pro section (tested in Firefox and GitHub app).