### PR TITLE
Delete duplicate `use Ecto.Migration`

### DIFF
--- a/lib/mix/tasks/oban.install.ex
+++ b/lib/mix/tasks/oban.install.ex
@@ -82,8 +82,6 @@ if Code.ensure_loaded?(Igniter) do
             end
 
           migration = """
-          use Ecto.Migration
-
           def up, do: Oban.Migration.up()
 
           def down, do: Oban.Migration.down(version: 1)


### PR DESCRIPTION
Given that `Igniter.Libs.Ecto.gen_migration/3` already includes `use Ecto.Migration`, as seen [here](https://github.com/ash-project/igniter/blob/588f09f81bb66bfae5fd3cf518a1484301f3d363/lib/igniter/libs/ecto.ex#L80), the duplicate inclusion is being removed.