### PR TITLE
Allow overriding Oban.Worker.new/1 to avoid compiler warning

### DIFF
--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -363,6 +363,7 @@ defmodule Oban.Worker do
 
   See `Oban.Job.new/2` for the available options.
   """
+  @callback new(args :: Job.args()) :: Job.changeset()
   @callback new(args :: Job.args(), opts :: [Job.option()]) :: Job.changeset()
 
   @doc """


### PR DESCRIPTION
When overriding the `new/1` and `new/2` functions defined for the Oban worker when it calls `use Oban.Worker`, if you override `new/2` with a default value for `opts`, it causes the following compiler warning:

```
    warning: this clause for new/1 cannot match because a previous clause at line 6 always matches
    │
  6 │   function, which is called with the full `Oban.Job` struct.
    │   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ deps/oban/lib/oban/worker.ex:6
```

This simple tweak seems to resolve that.  Please feel free to change this however you see fit.  TIA!