### PR TITLE
Allow for non-double errors in perform handling

### DIFF
--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -165,9 +165,13 @@ defmodule Oban.Queue.Executor do
         %{exec | result: result, state: :snoozed, snooze: seconds}
 
       returned ->
-        log_warning(exec, returned)
-
-        %{exec | state: :success, result: returned}
+        if is_tuple(returned) and elem(returned, 0) == :error do
+          %{exec | result: result, state: :failure, error: perform_error(worker, result)}
+        else 
+          log_warning(exec, returned)
+  
+          %{exec | state: :success, result: returned}
+        end
     end
   rescue
     error ->


### PR DESCRIPTION
A few libraries return tuples that have `:error` as a first element but also don't conform to `{atom(), any()}` instead opting for more data, for example the notable Ecto.Mutli returns: `{:error, :successful_event, Ecto.Changeset.t(), list(Ecto.Changeset.t())}`

Right now every oban user who has a job that ends in a Multi that errors out might not be seeing failures that they would normally see if they had used the function version of `Ecto.Repo.transact()`.

I realize that this is probably not enough to get merged and I am willing to spend time on any change requests or additional efforts (like testing) once I approval to continue.